### PR TITLE
Feature: The PHP deployment tool with support for popular frameworks out of the box.

### DIFF
--- a/.ddev/commands/web/dep
+++ b/.ddev/commands/web/dep
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: execute deployer dep command
+## Usage: dep <command>
+## Example: "dep deploy"
+## ProjectTypes: magento2
+
+vendor/bin/dep -f=deployer/deploy.php $*

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ atlassian*
 /.gitattributes
 /app/config_sandbox
 /app/code/Magento/TestModule*
+/deployer/deployer.env.php
 /lib/internal/flex/uploader/.actionScriptProperties
 /lib/internal/flex/uploader/.flexProperties
 /lib/internal/flex/uploader/.project

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "require-dev": {
         "allure-framework/allure-phpunit": "~1.5.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+        "deployer/deployer": "^7.1",
         "friendsofphp/php-cs-fixer": "~3.4.0",
         "lusitanian/oauth": "~0.8.10",
         "magento/magento-coding-standard": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "341a9b32238aa1da1dfacf8de658dd51",
+    "content-hash": "dd471e75b263992568b3c6e55c7f16e6",
     "packages": [
         {
             "name": "2tvenom/cborencode",
@@ -16753,50 +16753,6 @@
             "time": "2022-06-21T01:22:39+00:00"
         },
         {
-            "name": "markshust/magento2-module-disabletwofactorauth",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/markshust/magento2-module-disabletwofactorauth.git",
-                "reference": "224c68d85479938f06ab2400148778575784871c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/markshust/magento2-module-disabletwofactorauth/zipball/224c68d85479938f06ab2400148778575784871c",
-                "reference": "224c68d85479938f06ab2400148778575784871c",
-                "shasum": ""
-            },
-            "require": {
-                "magento/framework": "^103",
-                "php": "^7||^8"
-            },
-            "type": "magento2-module",
-            "autoload": {
-                "files": [
-                    "registration.php"
-                ],
-                "psr-4": {
-                    "MarkShust\\DisableTwoFactorAuth\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The DisableTwoFactorAuth module provides the ability to disable two-factor authentication.",
-            "support": {
-                "issues": "https://github.com/markshust/magento2-module-disabletwofactorauth/issues",
-                "source": "https://github.com/markshust/magento2-module-disabletwofactorauth/tree/2.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/markshust",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-10-24T17:11:14+00:00"
-        },
-        {
             "name": "monolog/monolog",
             "version": "2.8.0",
             "source": {
@@ -22227,6 +22183,49 @@
             "time": "2022-02-04T12:51:07+00:00"
         },
         {
+            "name": "deployer/deployer",
+            "version": "v7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deployphp/deployer.git",
+                "reference": "28934ad0af2b70dbd9cc60b33c5454778b3dd6c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deployphp/deployer/zipball/28934ad0af2b70dbd9cc60b33c5454778b3dd6c1",
+                "reference": "28934ad0af2b70dbd9cc60b33c5454778b3dd6c1",
+                "shasum": ""
+            },
+            "bin": [
+                "dep"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Medvedev",
+                    "email": "anton@medv.io"
+                }
+            ],
+            "description": "Deployment Tool",
+            "homepage": "https://deployer.org",
+            "support": {
+                "docs": "https://deployer.org/docs",
+                "issues": "https://github.com/deployphp/deployer/issues",
+                "source": "https://github.com/deployphp/deployer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/antonmedv",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-01-09T10:14:17+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.14.2",
             "source": {
@@ -23004,6 +23003,50 @@
                 "source": "https://github.com/magento/magento2-functional-testing-framework/tree/3.12.0"
             },
             "time": "2022-12-06T06:50:38+00:00"
+        },
+        {
+            "name": "markshust/magento2-module-disabletwofactorauth",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markshust/magento2-module-disabletwofactorauth.git",
+                "reference": "224c68d85479938f06ab2400148778575784871c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markshust/magento2-module-disabletwofactorauth/zipball/224c68d85479938f06ab2400148778575784871c",
+                "reference": "224c68d85479938f06ab2400148778575784871c",
+                "shasum": ""
+            },
+            "require": {
+                "magento/framework": "^103",
+                "php": "^7||^8"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "MarkShust\\DisableTwoFactorAuth\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The DisableTwoFactorAuth module provides the ability to disable two-factor authentication.",
+            "support": {
+                "issues": "https://github.com/markshust/magento2-module-disabletwofactorauth/issues",
+                "source": "https://github.com/markshust/magento2-module-disabletwofactorauth/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/markshust",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-10-24T17:11:14+00:00"
         },
         {
             "name": "mustache/mustache",

--- a/deployer/deploy.php
+++ b/deployer/deploy.php
@@ -1,0 +1,33 @@
+<?php
+namespace Deployer;
+
+/**
+ * Deployer's default recipe for deploying Magento2 projects.
+ * Can be used for testing and/or as starting pointing for new projects.
+ *
+ * Remember that while this will deploy the code, you still need to prepare your server properly for Magento2 projects.
+ * Check out the Magento documentation for more details: https://devdocs.magento.com/guides/v2.3/install-gde/install-flow-diagram.html
+ *
+ */
+require 'recipe/magento2.php';
+
+/**
+ * To avoid hard-coding values, we can use this environment-specific configuration file.
+ * Copy/paste the deployer.env.php.sample file, enter the right values, and rename it to deployer.env.php
+ *
+ */
+$configurations = include 'deployer.env.php';
+
+// Config
+
+set('repository', 'git@github.com:ivancukns/magento2-ddev.git');
+
+// Hosts
+
+host($configurations['remote_ip'])
+    ->set('remote_user', $configurations['remote_user'])
+    ->set('deploy_path', $configurations['deploy_path']);
+
+// Hooks
+
+after('deploy:failed', 'deploy:unlock');

--- a/deployer/deployer.env.php.sample
+++ b/deployer/deployer.env.php.sample
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'remote_ip' => '0.0.0.0',
+    'remote_user' => 'user',
+    'deploy_path' => '~/magento2-ddev'
+];


### PR DESCRIPTION
- add deployer/deployer package. More info about the tool: https://deployer.org
- basic configuration file for the deploy.php
- move deploy.php out of the root
- create ddev command to execute the dep commands
- git ignore non-sample deployer configuration files